### PR TITLE
Athena - Make query results configurable

### DIFF
--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -196,33 +196,49 @@ class AthenaBackend(BaseBackend):
 
     def get_query_results(self, exec_id: str) -> QueryResults:
         """
-        Queries are not executed, so this call will always return 0 rows by default.
+        Queries are not executed by Moto, so this call will always return 0 rows by default.
 
-        When using decorators, you can use the internal API to manually set results:
+        You can use a dedicated API to configure this. Moto has a queue that can be filled with the expected results.
+
+        A request to `get_query_results` will take the first result from that queue, and assign it to the provided QueryExecutionId. Subsequent requests using the same QueryExecutionId will return the same result. Other requests using a different QueryExecutionId will take the next result from the queue, or return an empty result if the queue is empty.
+
+        Configuring this queue by making a HTTP request to `/moto-api/static/athena/query-results`. An example invocation looks like this:
 
         .. sourcecode:: python
 
-            from moto.athena.models import athena_backends, QueryResults
-            from moto.core import DEFAULT_ACCOUNT_ID
+            expected_results = {
+                "account_id": "123456789012",  # This is the default - can be omitted
+                "region": "us-east-1",  # This is the default - can be omitted
+                "results": [
+                    {
+                        "rows": [{"Data": [{"VarCharValue": "1"}]}],
+                        "column_info": [{
+                            "CatalogName": "string",
+                            "SchemaName": "string",
+                            "TableName": "string",
+                            "Name": "string",
+                            "Label": "string",
+                            "Type": "string",
+                            "Precision": 123,
+                            "Scale": 123,
+                            "Nullable": "NOT_NULL",
+                            "CaseSensitive": True,
+                        }],
+                    },
+                    # other results as required
+                ],
+            }
+            resp = requests.post(
+                "http://motoapi.amazonaws.com:5000/moto-api/static/athena/query-results",
+                json=athena_result,
+            )
+            resp.status_code.should.equal(201)
 
-            backend = athena_backends[DEFAULT_ACCOUNT_ID]["us-east-1"]
-            rows = [{'Data': [{'VarCharValue': '..'}]}]
-            column_info = [{
-                              'CatalogName': 'string',
-                              'SchemaName': 'string',
-                              'TableName': 'string',
-                              'Name': 'string',
-                              'Label': 'string',
-                              'Type': 'string',
-                              'Precision': 123,
-                              'Scale': 123,
-                              'Nullable': 'NOT_NULL',
-                              'CaseSensitive': True
-                          }]
-            results = QueryResults(rows=rows, column_info=column_info)
-            backend.query_results["test"] = results
+            client = boto3.client("athena", region_name="us-east-1")
+            details = client.get_query_execution(QueryExecutionId="any_id")["QueryExecution"]
 
-            result = client.get_query_results(QueryExecutionId="test")
+        .. note:: The exact QueryExecutionId is not relevant here, but will likely be whatever value is returned by start_query_execution
+
         """
         if exec_id not in self.query_results and self.query_results_queue:
             self.query_results[exec_id] = self.query_results_queue.pop(0)

--- a/moto/moto_api/_internal/models.py
+++ b/moto/moto_api/_internal/models.py
@@ -1,6 +1,6 @@
 from moto.core import BaseBackend, DEFAULT_ACCOUNT_ID
 from moto.core.model_instances import reset_model_data
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 class MotoAPIBackend(BaseBackend):
@@ -35,21 +35,16 @@ class MotoAPIBackend(BaseBackend):
 
     def set_athena_result(
         self,
-        query_execution_id: Optional[str],
         rows: List[Dict[str, Any]],
-        column_info: Optional[List[Dict[str, str]]] = None,
-        region: str = "us-east-1",
+        column_info: List[Dict[str, str]],
+        account_id: str,
+        region: str,
     ) -> None:
         from moto.athena.models import athena_backends, QueryResults
 
-        if column_info is None:
-            column_info = []
-        backend = athena_backends[DEFAULT_ACCOUNT_ID][region]
+        backend = athena_backends[account_id][region]
         results = QueryResults(rows=rows, column_info=column_info)
-        if query_execution_id:
-            backend.query_results[query_execution_id] = results
-        else:
-            backend.query_result_queue.append(results)
+        backend.query_results_queue.append(results)
 
 
 moto_api_backend = MotoAPIBackend(region_name="global", account_id=DEFAULT_ACCOUNT_ID)

--- a/moto/moto_api/_internal/urls.py
+++ b/moto/moto_api/_internal/urls.py
@@ -12,7 +12,7 @@ url_paths = {
     "{0}/moto-api/reset": response_instance.reset_response,
     "{0}/moto-api/reset-auth": response_instance.reset_auth_response,
     "{0}/moto-api/seed": response_instance.seed,
-    "{0}/moto-api/static/athena/account/region/query_executions": response_instance.set_athena_result,
+    "{0}/moto-api/static/athena/query-results": response_instance.set_athena_result,
     "{0}/moto-api/state-manager/get-transition": response_instance.get_transition,
     "{0}/moto-api/state-manager/set-transition": response_instance.set_transition,
     "{0}/moto-api/state-manager/unset-transition": response_instance.unset_transition,

--- a/tests/test_athena/test_athena.py
+++ b/tests/test_athena/test_athena.py
@@ -303,6 +303,8 @@ def test_get_query_results():
                 "CaseSensitive": True,
             }
         ]
+        # This was the documented way to configure query results, before `moto-api/static/athena/query_results` was implemented
+        # We should try to keep this for backward compatibility
         results = QueryResults(rows=rows, column_info=column_info)
         backend.query_results["test"] = results
 

--- a/tests/test_athena/test_athena_server_api.py
+++ b/tests/test_athena/test_athena_server_api.py
@@ -1,49 +1,161 @@
+import boto3
 import requests
 
-from moto import mock_athena, settings
-from unittest import SkipTest
+from moto import mock_athena, mock_sts, settings
 
 
-# boto3.set_stream_logger(name='botocore')
+DEFAULT_COLUMN_INFO = [
+    {
+        "CatalogName": "string",
+        "SchemaName": "string",
+        "TableName": "string",
+        "Name": "string",
+        "Label": "string",
+        "Type": "string",
+        "Precision": 123,
+        "Scale": 123,
+        "Nullable": "NOT_NULL",
+        "CaseSensitive": True,
+    }
+]
 
 
 @mock_athena
 def test_set_athena_result():
-    if not settings.TEST_SERVER_MODE:
-        raise SkipTest("We only want to test ServerMode here")
-
-    requests.get(
-        "http://localhost:5000/moto-api/seed?a=42",
+    base_url = (
+        "localhost:5000" if settings.TEST_SERVER_MODE else "motoapi.amazonaws.com"
     )
-    exex_id = "bdd640fb-0667-4ad1-9c80-317fa3b1799d"
+
     athena_result = {
-        "region": "eu-west-1",
-        "query_execution_id": exex_id,
-        "rows": [
-            {"Headers": ["first_column"]},
-            {"Data": [{"VarCharValue": "1"}]},
-        ],
-        "column_info": [
+        "results": [
             {
-                "CatalogName": "string",
-                "SchemaName": "string",
-                "TableName": "string",
-                "Name": "string",
-                "Label": "string",
-                "Type": "string",
-                "Precision": 123,
-                "Scale": 123,
-                "Nullable": "NOT_NULL",
-                "CaseSensitive": True,
+                "rows": [
+                    {"Data": [{"VarCharValue": "1"}]},
+                ],
+                "column_info": DEFAULT_COLUMN_INFO,
             }
-        ],
+        ]
     }
     resp = requests.post(
-        "http://localhost:5000/moto-api/static/athena/account/region/query_executions",
+        f"http://{base_url}/moto-api/static/athena/query-results",
         json=athena_result,
     )
     resp.status_code.should.equal(201)
 
-    # client = boto3.client("athena", region_name="eu-west-1")
-    # details = client.get_query_execution(QueryExecutionId=exex_id)["QueryExecution"]
-    # details.should.equal(athena_result)
+    client = boto3.client("athena", region_name="us-east-1")
+    details = client.get_query_results(QueryExecutionId="anyid")["ResultSet"]
+    details["Rows"].should.equal(athena_result["results"][0]["rows"])
+    details["ResultSetMetadata"]["ColumnInfo"].should.equal(DEFAULT_COLUMN_INFO)
+
+    # Operation should be idempotent
+    details = client.get_query_results(QueryExecutionId="anyid")["ResultSet"]
+    details["Rows"].should.equal(athena_result["results"][0]["rows"])
+
+    # Different ID should still return different (default) results though
+    details = client.get_query_results(QueryExecutionId="otherid")["ResultSet"]
+    details["Rows"].should.equal([])
+
+
+@mock_athena
+def test_set_multiple_athena_result():
+    base_url = (
+        "localhost:5000" if settings.TEST_SERVER_MODE else "motoapi.amazonaws.com"
+    )
+
+    athena_result = {
+        "results": [
+            {"rows": [{"Data": [{"VarCharValue": "1"}]}]},
+            {"rows": [{"Data": [{"VarCharValue": "2"}]}]},
+            {"rows": [{"Data": [{"VarCharValue": "3"}]}]},
+        ]
+    }
+    resp = requests.post(
+        f"http://{base_url}/moto-api/static/athena/query-results",
+        json=athena_result,
+    )
+    resp.status_code.should.equal(201)
+
+    client = boto3.client("athena", region_name="us-east-1")
+    details = client.get_query_results(QueryExecutionId="first_id")["ResultSet"]
+    details["Rows"].should.equal([{"Data": [{"VarCharValue": "1"}]}])
+
+    # The same ID should return the same data
+    details = client.get_query_results(QueryExecutionId="first_id")["ResultSet"]
+    details["Rows"].should.equal([{"Data": [{"VarCharValue": "1"}]}])
+
+    # The next ID should return different data
+    details = client.get_query_results(QueryExecutionId="second_id")["ResultSet"]
+    details["Rows"].should.equal([{"Data": [{"VarCharValue": "2"}]}])
+
+    # The last ID should return even different data
+    details = client.get_query_results(QueryExecutionId="third_id")["ResultSet"]
+    details["Rows"].should.equal([{"Data": [{"VarCharValue": "3"}]}])
+
+    # Any other calls should return the default data
+    details = client.get_query_results(QueryExecutionId="other_id")["ResultSet"]
+    details["Rows"].should.equal([])
+
+
+@mock_athena
+@mock_sts
+def test_set_athena_result_with_custom_region_account():
+    base_url = (
+        "localhost:5000" if settings.TEST_SERVER_MODE else "motoapi.amazonaws.com"
+    )
+
+    athena_result = {
+        "account_id": "222233334444",
+        "region": "eu-west-1",
+        "results": [
+            {
+                "rows": [
+                    {"Data": [{"VarCharValue": "1"}]},
+                ],
+                "column_info": DEFAULT_COLUMN_INFO,
+            }
+        ],
+    }
+    resp = requests.post(
+        f"http://{base_url}/moto-api/static/athena/query-results",
+        json=athena_result,
+    )
+    resp.status_code.should.equal(201)
+
+    sts = boto3.client("sts", "us-east-1")
+    cross_account_creds = sts.assume_role(
+        RoleArn="arn:aws:iam::222233334444:role/role-in-another-account",
+        RoleSessionName="test-session-name",
+        ExternalId="test-external-id",
+    )["Credentials"]
+
+    athena_in_other_account = boto3.client(
+        "athena",
+        aws_access_key_id=cross_account_creds["AccessKeyId"],
+        aws_secret_access_key=cross_account_creds["SecretAccessKey"],
+        aws_session_token=cross_account_creds["SessionToken"],
+        region_name="eu-west-1",
+    )
+
+    details = athena_in_other_account.get_query_results(QueryExecutionId="anyid")[
+        "ResultSet"
+    ]
+    details["Rows"].should.equal(athena_result["results"][0]["rows"])
+    details["ResultSetMetadata"]["ColumnInfo"].should.equal(DEFAULT_COLUMN_INFO)
+
+    # query results from other regions do not match
+    athena_in_diff_region = boto3.client(
+        "athena",
+        aws_access_key_id=cross_account_creds["AccessKeyId"],
+        aws_secret_access_key=cross_account_creds["SecretAccessKey"],
+        aws_session_token=cross_account_creds["SessionToken"],
+        region_name="eu-west-2",
+    )
+    details = athena_in_diff_region.get_query_results(QueryExecutionId="anyid")[
+        "ResultSet"
+    ]
+    details["Rows"].should.equal([])
+
+    # query results from default account does not match
+    client = boto3.client("athena", region_name="eu-west-1")
+    details = client.get_query_results(QueryExecutionId="anyid")["ResultSet"]
+    details["Rows"].should.equal([])


### PR DESCRIPTION
Small improvements to your Athena PR:

 - The URL is now `/moto-api/static/athena/query-results` - shorter, more readable, and better describes what is being posted IMO
 - The account-id/region are now part of the body (going against my earlier advice, but for most people these fields aren't necessary - so having them part of the body means they can be omitted if necessary)
 - Removed the option to pass the QueryExecutionId as part of the body. As I understand it, this wouldn't be part of your workflow anyway, so I'd rather not add complexity until there's a demand for it

The full diff with both are changes combined can be seen here: https://github.com/getmoto/moto/compare/master...bblommers:feature/athena-query-results

As far as I can see this is the most user-friendly/simplest way to achieve this feature, but let me know what you think - happy to adjust if I've missed anything.